### PR TITLE
Revert "feat(helm): update chart longhorn to 1.6.0"

### DIFF
--- a/kubernetes/apps/storage/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/longhorn/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: longhorn
-      version: 1.6.0
+      version: 1.5.3
       sourceRef:
         kind: HelmRepository
         name: longhorn


### PR DESCRIPTION
Reverts TorStava/k3s-flux-homelab#655

Upgrade cannot be completed. Waiting for 1.6.1 to see if the issue is resolved. If not, more detailed troubleshooting in the cluster will be required.